### PR TITLE
Feature/gradient color picker@mav

### DIFF
--- a/lib/pixels.dart
+++ b/lib/pixels.dart
@@ -1,7 +1,8 @@
 library pixels;
 
 export 'src/editable_pixel_image.dart';
-export 'src/pixel_color_picker.dart';
+export 'src/pallete_color_picker.dart';
+export 'src/gradient_color_picker.dart';
 export 'src/pixel_editor.dart';
 export 'src/pixel_image.dart';
 export 'src/pixel_palette.dart';

--- a/lib/src/editable_pixel_image.dart
+++ b/lib/src/editable_pixel_image.dart
@@ -185,38 +185,11 @@ class PixelImageController extends ValueNotifier<_PixelImageValue> {
   /// Sets a specific pixel in the [EditablePixelImage] controlled by the
   /// controller.
   void setPixel({
-    required int colorIndex,
-    required int x,
-    required int y,
-  }) {
-    if (palette == null) return;
-    setPixelIndex(
-      pixelIndex: y * width + x,
-      colorIndex: colorIndex,
-    );
-    _update();
-  }
-
-  /// Sets a specific pixel in the [EditablePixelImage] controlled by the
-  /// controller.
-  void setPixelIndex({
-    required pixelIndex,
-    required colorIndex,
-  }) {
-    if (palette == null) return;
-    _pixelBytes[pixelIndex] = colorIndex;
-    _update();
-  }
-
-  /// Sets a specific pixel in the [EditablePixelImage] controlled by the
-  /// controller.
-  void setPixelColor({
     required Color color,
     required int x,
     required int y,
   }) {
-    if (palette != null) return;
-    setPixelIndexColor(
+    setPixelIndex(
       pixelIndex: y * width + x,
       color: color,
     );
@@ -225,11 +198,10 @@ class PixelImageController extends ValueNotifier<_PixelImageValue> {
 
   /// Sets a specific pixel in the [EditablePixelImage] controlled by the
   /// controller.
-  void setPixelIndexColor({
+  void setPixelIndex({
     required pixelIndex,
     required color,
   }) {
-    if (palette != null) return;
     _pixelBytes[pixelIndex * 4 + 0] = color.red;
     _pixelBytes[pixelIndex * 4 + 1] = color.green;
     _pixelBytes[pixelIndex * 4 + 2] = color.blue;

--- a/lib/src/gradient_color_picker.dart
+++ b/lib/src/gradient_color_picker.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+
+/// A gradient-equation based color picker. It can be displayed vertically or
+/// horizontally depending on the [direction].
+class GradientColorPicker extends StatelessWidget {
+  /// Defines if the color picker should be displayed horizontally or
+  /// vertically.
+  final Axis direction;
+
+  /// A callback for when the user picks a color.
+  final void Function(Color color) onSelected;
+
+  /// A callback to calculate the color
+  final Color Function(double y) equation;
+
+  /// The width or height (depending on it's direction) of the color picker.
+  final double crossAxisWidth;
+
+  /// Dictates the resolution of the visualized gradient. More = smoother.
+  final int bands = 255;
+
+  /// Creates a new [GradientColorPicker].
+  const GradientColorPicker({
+    required this.equation,
+    required this.onSelected,
+    this.direction = Axis.horizontal,
+    this.crossAxisWidth = 32.0,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: direction == Axis.vertical ? crossAxisWidth : null,
+      height: direction == Axis.horizontal ? crossAxisWidth : null,
+      child: Flex(
+        direction: direction,
+        mainAxisSize: MainAxisSize.max,
+        children: [
+          Expanded(
+            flex: 1,
+            child: _GradientColorPickerWell(
+              equation: equation,
+              onTap: (x, y) {
+                onSelected(equation(y));
+              },
+              bands: bands,
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class _GradientColorPickerWell extends StatelessWidget {
+  final Function(double x, double y) onTap;
+  final GlobalKey colorGradKey = GlobalKey(debugLabel: "colorGradient");
+  final Color Function(double y) equation;
+  final int bands;
+
+  _GradientColorPickerWell({
+    required this.equation,
+    required this.onTap,
+    required this.bands,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Color> colors = [];
+    final List<double> stops = List.filled(bands, 0.0);
+
+    for (int i = 0; i < bands; i++) {
+      colors.add(equation(i / bands));
+      stops[i] = i / bands;
+    }
+
+    return GestureDetector(
+        onTapDown: (details) {
+          final RenderBox renderBox =
+              colorGradKey.currentContext?.findRenderObject() as RenderBox;
+          final size = renderBox.size;
+          final double x = details.localPosition.dx / size.width;
+          final double y = details.localPosition.dy / size.height;
+          onTap(x, y);
+        },
+        child: Container(
+          key: colorGradKey,
+          decoration: BoxDecoration(
+              gradient: LinearGradient(
+            begin: Alignment.topRight,
+            end: Alignment.bottomLeft,
+            stops: stops,
+            colors: colors,
+          )),
+        ));
+  }
+}

--- a/lib/src/gradient_color_picker.dart
+++ b/lib/src/gradient_color_picker.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 
 /// A gradient-equation based color picker. It can be displayed vertically or
@@ -19,12 +21,20 @@ class GradientColorPicker extends StatelessWidget {
   /// Dictates the resolution of the visualized gradient. More = smoother.
   final int bands = 255;
 
+  /// Changes the slider gizmo color
+  final Color sliderColor;
+
+  /// Sets the gizmo starting position
+  final double sliderStartOffset;
+
   /// Creates a new [GradientColorPicker].
   const GradientColorPicker({
     required this.equation,
     required this.onSelected,
     this.direction = Axis.horizontal,
     this.crossAxisWidth = 32.0,
+    this.sliderColor = Colors.white,
+    this.sliderStartOffset = 0.5,
     super.key,
   });
 
@@ -40,12 +50,13 @@ class GradientColorPicker extends StatelessWidget {
           Expanded(
             flex: 1,
             child: _GradientColorPickerWell(
-              equation: equation,
-              onTap: (x, y) {
-                onSelected(equation(y));
-              },
-              bands: bands,
-            ),
+                equation: equation,
+                onTap: (x, y) =>
+                    onSelected(equation(direction == Axis.horizontal ? x : y)),
+                bands: bands,
+                sliderColor: sliderColor,
+                sliderStartOffset: sliderStartOffset,
+                direction: direction),
           )
         ],
       ),
@@ -53,48 +64,138 @@ class GradientColorPicker extends StatelessWidget {
   }
 }
 
-class _GradientColorPickerWell extends StatelessWidget {
+class _GradientColorPickerWell extends StatefulWidget {
   final Function(double x, double y) onTap;
   final GlobalKey colorGradKey = GlobalKey(debugLabel: "colorGradient");
   final Color Function(double y) equation;
   final int bands;
+  final Color sliderColor;
+  final double sliderStartOffset;
+  final Axis direction;
 
-  _GradientColorPickerWell({
-    required this.equation,
-    required this.onTap,
-    required this.bands,
-  });
+  _GradientColorPickerWell(
+      {required this.equation,
+      required this.onTap,
+      required this.bands,
+      required this.sliderColor,
+      required this.sliderStartOffset,
+      required this.direction});
 
-  @override
-  Widget build(BuildContext context) {
-    final List<Color> colors = [];
-    final List<double> stops = List.filled(bands, 0.0);
-
-    for (int i = 0; i < bands; i++) {
-      colors.add(equation(i / bands));
-      stops[i] = i / bands;
-    }
-
-    return GestureDetector(
-        onTapDown: handleTapDown,
-        child: Container(
-          key: colorGradKey,
-          decoration: BoxDecoration(
-              gradient: LinearGradient(
-            begin: Alignment.topRight,
-            end: Alignment.bottomLeft,
-            stops: stops,
-            colors: colors,
-          )),
-        ));
-  }
-
-  void handleTapDown(details) {
+  Point pointFromTapDetails(details) {
     final RenderBox renderBox =
         colorGradKey.currentContext?.findRenderObject() as RenderBox;
     final size = renderBox.size;
     final double x = details.localPosition.dx / size.width;
     final double y = details.localPosition.dy / size.height;
-    onTap(x, y);
+    return Point(x, y);
   }
+
+  @override
+  State<_GradientColorPickerWell> createState() {
+    return _GradientColorPickerWellState();
+  }
+}
+
+class _GradientColorPickerWellState extends State<_GradientColorPickerWell> {
+  late double offset;
+
+  @override
+  void initState() {
+    offset = widget.sliderStartOffset;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Color> colors = [];
+    final List<double> stops = List.filled(widget.bands, 0.0);
+
+    for (int i = 0; i < widget.bands; i++) {
+      double alpha = i / widget.bands;
+
+      if (widget.direction == Axis.horizontal) {
+        alpha = 1.0 - alpha;
+      }
+
+      colors.add(widget.equation(alpha));
+      stops[i] = i / widget.bands;
+    }
+
+    return GestureDetector(
+        onTapDown: (details) {
+          final p = widget.pointFromTapDetails(details);
+          final double x = p.x.toDouble();
+          final double y = p.y.toDouble();
+          widget.onTap(x, y);
+          setState(() {
+            offset = widget.direction == Axis.horizontal ? x : y;
+          });
+        },
+        child: Stack(children: [
+          makeSliderGizmo(),
+          Container(
+            key: widget.colorGradKey,
+            decoration: BoxDecoration(
+                gradient: LinearGradient(
+              begin: Alignment.topRight,
+              end: Alignment.bottomLeft,
+              stops: stops,
+              colors: colors,
+            )),
+          ),
+          makeSliderGizmo(),
+        ]));
+  }
+
+  Widget makeSliderGizmo() => CustomPaint(
+        size: Size.infinite,
+        painter: GradientSliderPainter(
+            offset, widget.direction, widget.bands, widget.sliderColor),
+        willChange: true,
+      );
+}
+
+/// Custom paints the slider gizmo
+class GradientSliderPainter extends CustomPainter {
+  /// The offset along the align axis
+  double offset;
+
+  /// The align axis
+  Axis direction;
+
+  /// Helps calculate where the slider should snap to
+  int bands;
+
+  /// The stroke color of the slider
+  Color borderColor;
+
+  /// Use the axis [offset] to position the gizmo
+  GradientSliderPainter(
+      this.offset, this.direction, this.bands, this.borderColor)
+      : super();
+
+  /// Paints a white rectangle representing the slider gizmo
+  @override
+  void paint(Canvas canvas, Size size) {
+    Offset center = Offset(size.width / 2.0, offset * size.height);
+    double width = size.width;
+    double height = size.height / bands;
+
+    if (direction == Axis.horizontal) {
+      center = Offset(offset * size.width, size.height / 2.0);
+      width = size.width / bands;
+      height = size.height;
+    }
+
+    canvas.drawRect(
+        Rect.fromCenter(center: center, width: width, height: height),
+        Paint()
+          ..color = borderColor
+          ..strokeWidth = 2.0
+          ..style = PaintingStyle.stroke);
+  }
+
+  /// Never repaint unless changed
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) => true;
 }

--- a/lib/src/gradient_color_picker.dart
+++ b/lib/src/gradient_color_picker.dart
@@ -76,14 +76,7 @@ class _GradientColorPickerWell extends StatelessWidget {
     }
 
     return GestureDetector(
-        onTapDown: (details) {
-          final RenderBox renderBox =
-              colorGradKey.currentContext?.findRenderObject() as RenderBox;
-          final size = renderBox.size;
-          final double x = details.localPosition.dx / size.width;
-          final double y = details.localPosition.dy / size.height;
-          onTap(x, y);
-        },
+        onTapDown: handleTapDown,
         child: Container(
           key: colorGradKey,
           decoration: BoxDecoration(
@@ -94,5 +87,14 @@ class _GradientColorPickerWell extends StatelessWidget {
             colors: colors,
           )),
         ));
+  }
+
+  void handleTapDown(details) {
+    final RenderBox renderBox =
+        colorGradKey.currentContext?.findRenderObject() as RenderBox;
+    final size = renderBox.size;
+    final double x = details.localPosition.dx / size.width;
+    final double y = details.localPosition.dy / size.height;
+    onTap(x, y);
   }
 }

--- a/lib/src/pallete_color_picker.dart
+++ b/lib/src/pallete_color_picker.dart
@@ -3,7 +3,7 @@ import 'package:pixels/src/pixel_palette.dart';
 
 /// A [PixelPalette] color picker. It can be displayed vertically or
 /// horizontally depending on the [direction].
-class PixelColorPicker extends StatelessWidget {
+class PaletteColorPicker extends StatelessWidget {
   /// The palette used by the color picker.
   final PixelPalette palette;
 
@@ -20,8 +20,8 @@ class PixelColorPicker extends StatelessWidget {
   /// The width or height (depending on it's direction) of the color picker.
   final double crossAxisWidth;
 
-  /// Creates a new [PixelColorPicker].
-  const PixelColorPicker({
+  /// Creates a new [PaletteColorPicker].
+  const PaletteColorPicker({
     required this.selectedIndex,
     required this.onChanged,
     required this.palette,
@@ -42,7 +42,7 @@ class PixelColorPicker extends StatelessWidget {
           for (var i = 0; i < palette.colors.length; i++)
             Expanded(
               flex: 1,
-              child: _PixelColorPickerWell(
+              child: _PalleteColorPickerWell(
                 index: i,
                 palette: palette,
                 selected: selectedIndex == i,
@@ -57,13 +57,13 @@ class PixelColorPicker extends StatelessWidget {
   }
 }
 
-class _PixelColorPickerWell extends StatelessWidget {
+class _PalleteColorPickerWell extends StatelessWidget {
   final int index;
   final PixelPalette palette;
   final bool selected;
   final VoidCallback onTap;
 
-  const _PixelColorPickerWell({
+  const _PalleteColorPickerWell({
     required this.index,
     required this.palette,
     required this.selected,

--- a/lib/src/pixel_editor.dart
+++ b/lib/src/pixel_editor.dart
@@ -1,6 +1,9 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:pixels/src/editable_pixel_image.dart';
-import 'package:pixels/src/pixel_color_picker.dart';
+import 'package:pixels/src/pallete_color_picker.dart';
+import 'package:pixels/src/gradient_color_picker.dart';
 
 /// A pixel editor widget where the colors and dimensions are specified in the
 /// [controller]. Whenver a pixel is set, [onSetPixel] is called. The pixel
@@ -25,7 +28,17 @@ class PixelEditor extends StatefulWidget {
 }
 
 class _PixelEditorState extends State<PixelEditor> {
-  int _selectedColor = 0;
+  int _selectedColorIndex = 0;
+  Color _selectedColor = const Color.fromARGB(255, 255, 255, 255);
+  Color _finalColor = const Color.fromARGB(255, 255, 255, 255);
+  double _selectedSaturation = 1.0;
+
+  Color saturate(Color colorIn) {
+    int r = (colorIn.red * _selectedSaturation).floor();
+    int g = (colorIn.green * _selectedSaturation).floor();
+    int b = (colorIn.blue * _selectedSaturation).floor();
+    return Color.fromARGB(colorIn.alpha, r, g, b);
+  }
 
   @override
   void initState() {
@@ -38,40 +51,117 @@ class _PixelEditorState extends State<PixelEditor> {
       var isHorizontal = constraints.maxWidth > constraints.maxHeight;
 
       return Flex(
-        direction: isHorizontal ? Axis.horizontal : Axis.vertical,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          EditablePixelImage(
-            controller: widget.controller,
-            onTappedPixel: (details) {
-              widget.controller.setPixel(
-                colorIndex: _selectedColor,
-                x: details.x,
-                y: details.y,
-              );
-              if (widget.onSetPixel != null) {
-                widget.onSetPixel!(
-                  SetPixelDetails._(
-                    tapDetails: details,
-                    colorIndex: _selectedColor,
-                  ),
-                );
-              }
-            },
-          ),
-          PixelColorPicker(
-            direction: isHorizontal ? Axis.vertical : Axis.horizontal,
-            palette: widget.controller.palette,
-            selectedIndex: _selectedColor,
-            onChanged: (index) {
-              setState(() {
-                _selectedColor = index;
-              });
-            },
-          ),
-        ],
-      );
+          direction: isHorizontal ? Axis.horizontal : Axis.vertical,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            EditablePixelImage(
+              controller: widget.controller,
+              onTappedPixel: handleTappedPixel,
+            ),
+            if (widget.controller.palette != null) ...[
+              makePaletteColorPicker(isHorizontal),
+            ] else ...[
+              makeSaturationGradientPicker(isHorizontal),
+              makeRainbowGradientPicker(isHorizontal),
+            ],
+          ]);
     });
+  }
+
+// uses palette picker tool for color selection
+  Widget makePaletteColorPicker(bool isHorizontal) {
+    return PaletteColorPicker(
+      direction: isHorizontal ? Axis.vertical : Axis.horizontal,
+      palette: widget.controller.palette!,
+      selectedIndex: _selectedColorIndex,
+      onChanged: (index) {
+        setState(() {
+          _selectedColorIndex = index;
+          _selectedColor =
+              widget.controller.palette!.colors[_selectedColorIndex];
+        });
+      },
+    );
+  }
+
+  // uses a linear equation to cycle through the rainbow
+  Widget makeRainbowGradientPicker(bool isHorizontal) {
+    return GradientColorPicker(
+      equation: (y) {
+        const pi2 = pi * 2.0;
+        double r = ((sin(y * pi2 + 2) + 1) / 2) * 255;
+        double g = ((sin(y * pi2 + 0) + 1) / 2) * 255;
+        double b = ((sin(y * pi2 + 4) + 1) / 2) * 255;
+        return Color.fromARGB(255, r.floor(), g.floor(), b.floor());
+      },
+      direction: isHorizontal ? Axis.vertical : Axis.horizontal,
+      onSelected: (color) {
+        setState(() {
+          _finalColor = saturate(_selectedColor = color);
+        });
+      },
+    );
+  }
+
+// uses a linear equation from black to white
+  Widget makeSaturationGradientPicker(bool isHorizontal) {
+    return GradientColorPicker(
+      equation: (y) {
+        int r = (y * 255).floor();
+        return Color.fromARGB(255, r, r, r);
+      },
+      direction: isHorizontal ? Axis.vertical : Axis.horizontal,
+      onSelected: (color) {
+        setState(() {
+          // convert to [0.0, 1.0] range for 0-100% intensity
+          _selectedSaturation = color.red / 255;
+          // mix
+          _finalColor = saturate(_selectedColor);
+        });
+      },
+    );
+  }
+
+  void handleTappedPixel(details) {
+    if (widget.controller.palette == null) {
+      handleColorTap(details);
+      return;
+    }
+
+    handlePaletteColorTap(details);
+  }
+
+  void handleColorTap(details) {
+    widget.controller.setPixelColor(
+      color: _finalColor,
+      x: details.x,
+      y: details.y,
+    );
+    if (widget.onSetPixel != null) {
+      widget.onSetPixel!(
+        SetPixelDetails._(
+          tapDetails: details,
+          colorValue: _finalColor,
+        ),
+      );
+    }
+  }
+
+  void handlePaletteColorTap(details) {
+    widget.controller.setPixel(
+      colorIndex: _selectedColorIndex,
+      x: details.x,
+      y: details.y,
+    );
+    if (widget.onSetPixel != null) {
+      widget.onSetPixel!(
+        SetPixelDetails._(
+          tapDetails: details,
+          colorIndex: _selectedColorIndex,
+          colorValue: widget.controller.palette!.colors[_selectedColorIndex],
+        ),
+      );
+    }
   }
 }
 
@@ -80,8 +170,12 @@ class SetPixelDetails {
   /// Information about where the pixel is located.
   final PixelTapDetails tapDetails;
 
-  /// The newly set color index of the pixel.
-  final int colorIndex;
+  /// The newly set palette color index of the pixel.
+  final int? colorIndex;
 
-  SetPixelDetails._({required this.tapDetails, required this.colorIndex});
+  /// The newly set color value of the pixel.
+  final Color colorValue;
+
+  SetPixelDetails._(
+      {required this.tapDetails, this.colorIndex, required this.colorValue});
 }

--- a/lib/src/pixel_editor.dart
+++ b/lib/src/pixel_editor.dart
@@ -32,18 +32,18 @@ class _PixelEditorState extends State<PixelEditor> {
   int _selectedColorIndex = 0;
   late Color _selectedColor;
   late Color _finalColor;
-  double _selectedSaturation = 0.5;
+  double _selectedLuminosity = 0.5;
 
-  /// Mixes [colorIn] by saturation `S`
-  /// S < 0.5 will darken, S > 0.5 will brighten
-  Color saturate(Color colorIn) {
+  /// Mixes [colorIn] by luminosity `L`
+  /// L < 0.5 will darken, S > 0.5 will brighten
+  Color luminate(Color colorIn) {
     final double r = colorIn.red.toDouble();
     final double g = colorIn.green.toDouble();
     final double b = colorIn.blue.toDouble();
-    final double S = 255 * (_selectedSaturation * 2 - 1);
-    final ri = clampDouble(r + S, 0, 255).toInt();
-    final gi = clampDouble(g + S, 0, 255).toInt();
-    final bi = clampDouble(b + S, 0, 255).toInt();
+    final double L = 255 * (_selectedLuminosity * 2 - 1);
+    final ri = clampDouble(r + L, 0, 255).toInt();
+    final gi = clampDouble(g + L, 0, 255).toInt();
+    final bi = clampDouble(b + L, 0, 255).toInt();
 
     return Color.fromARGB(colorIn.alpha, ri, gi, bi);
   }
@@ -80,7 +80,7 @@ class _PixelEditorState extends State<PixelEditor> {
             if (widget.controller.palette != null) ...[
               makePaletteColorPicker(isHorizontal),
             ] else ...[
-              makeSaturationGradientPicker(isHorizontal),
+              makeLumenGradientPicker(isHorizontal),
               makeRainbowGradientPicker(isHorizontal),
             ],
           ]);
@@ -109,7 +109,7 @@ class _PixelEditorState extends State<PixelEditor> {
       equation: sampleRainbowColor,
       onSelected: (color) {
         setState(() {
-          _finalColor = saturate(_selectedColor = color);
+          _finalColor = luminate(_selectedColor = color);
         });
       },
       direction: isHorizontal ? Axis.vertical : Axis.horizontal,
@@ -118,7 +118,7 @@ class _PixelEditorState extends State<PixelEditor> {
   }
 
 // uses a linear equation from black to white
-  Widget makeSaturationGradientPicker(bool isHorizontal) {
+  Widget makeLumenGradientPicker(bool isHorizontal) {
     return GradientColorPicker(
       equation: (y) {
         int r = (y * 255).floor();
@@ -127,14 +127,14 @@ class _PixelEditorState extends State<PixelEditor> {
       onSelected: (color) {
         setState(() {
           // convert to [0.0, 1.0] range for 0-100% intensity
-          _selectedSaturation = color.red / 255;
+          _selectedLuminosity = color.red / 255;
           // mix
-          _finalColor = saturate(_selectedColor);
+          _finalColor = luminate(_selectedColor);
         });
       },
       direction: isHorizontal ? Axis.vertical : Axis.horizontal,
       sliderColor: Colors.yellow,
-      sliderStartOffset: _selectedSaturation,
+      sliderStartOffset: _selectedLuminosity,
     );
   }
 

--- a/lib/src/pixel_image.dart
+++ b/lib/src/pixel_image.dart
@@ -14,7 +14,7 @@ class PixelImage extends StatefulWidget {
   final int height;
 
   /// The palette used by this image.
-  final PixelPalette palette;
+  final PixelPalette? palette;
 
   /// The [ByteData] representing the pixels in the image. Each byte corresponds
   /// to one pixel.
@@ -24,13 +24,16 @@ class PixelImage extends StatefulWidget {
   const PixelImage({
     required this.width,
     required this.height,
-    required this.palette,
+    this.palette,
     required this.pixels,
     super.key,
   });
 
   @override
   State<PixelImage> createState() => _PixelImageState();
+
+  /// calculate the image's 2D area
+  int get area => width * height;
 }
 
 class _PixelImageState extends State<PixelImage> {
@@ -43,15 +46,18 @@ class _PixelImageState extends State<PixelImage> {
   }
 
   Future<void> _updateUIImage() async {
-    assert(widget.pixels.lengthInBytes == widget.width * widget.height);
+    assert(widget.pixels.lengthInBytes == widget.area * 4);
 
-    var dstImageBytes = Uint8List(widget.width * widget.height * 4);
+    var dstImageBytes = Uint8List(widget.area * 4);
 
     var srcPixels = widget.pixels.buffer.asUint8List();
 
     // Iterate over all pixels.
-    for (var i = 0; i < widget.width * widget.height; i++) {
-      var color = widget.palette.colors[srcPixels[i]];
+    for (var i = 0; i < widget.area; i++) {
+      var color = widget.palette?.colors[srcPixels[i]] ??
+          Color.fromARGB(srcPixels[i * 4 + 3], srcPixels[i * 4 + 0],
+              srcPixels[i * 4 + 1], srcPixels[i * 4 + 2]);
+
       var r = color.red;
       var g = color.green;
       var b = color.blue;

--- a/lib/src/pixel_image.dart
+++ b/lib/src/pixel_image.dart
@@ -53,7 +53,7 @@ class _PixelImageState extends State<PixelImage> {
     var srcPixels = widget.pixels.buffer.asUint8List();
 
     // Iterate over all pixels.
-    for (var i = 0; i < widget.area; i++) {
+    for (int i = 0; i < widget.area; i++) {
       var color = widget.palette?.colors[srcPixels[i]] ??
           Color.fromARGB(srcPixels[i * 4 + 3], srcPixels[i * 4 + 0],
               srcPixels[i * 4 + 1], srcPixels[i * 4 + 2]);

--- a/lib/src/pixel_image.dart
+++ b/lib/src/pixel_image.dart
@@ -48,28 +48,8 @@ class _PixelImageState extends State<PixelImage> {
   Future<void> _updateUIImage() async {
     assert(widget.pixels.lengthInBytes == widget.area * 4);
 
-    var dstImageBytes = Uint8List(widget.area * 4);
-
-    var srcPixels = widget.pixels.buffer.asUint8List();
-
-    // Iterate over all pixels.
-    for (int i = 0; i < widget.area; i++) {
-      var color = widget.palette?.colors[srcPixels[i]] ??
-          Color.fromARGB(srcPixels[i * 4 + 3], srcPixels[i * 4 + 0],
-              srcPixels[i * 4 + 1], srcPixels[i * 4 + 2]);
-
-      var r = color.red;
-      var g = color.green;
-      var b = color.blue;
-      var a = color.alpha;
-
-      dstImageBytes[i * 4 + 0] = r;
-      dstImageBytes[i * 4 + 1] = g;
-      dstImageBytes[i * 4 + 2] = b;
-      dstImageBytes[i * 4 + 3] = a;
-    }
-
-    var immutableBuffer = await ui.ImmutableBuffer.fromUint8List(dstImageBytes);
+    var immutableBuffer = await ui.ImmutableBuffer.fromUint8List(
+        widget.pixels.buffer.asUint8List());
     var imageDescriptor = ui.ImageDescriptor.raw(
       immutableBuffer,
       width: widget.width,


### PR DESCRIPTION
Adds the following features:
- optional initial background color
- new gradient picker abstraction with an equation callback to color the `BoxDecorator`
- comes with a slider widget to indicate where the color was clicked
- gradient picker used to sample colors from the rainbow
- gradient picker used to sample luminosity
- can hold click/drag finger to draw continuously

Changes:
- Not using the color buffer to store palette indices. The color is read from the palette list and drawn to that pixel directly
  - this was needed to let background colors work
- Palette index is now optional in the callback tap details object for this reason. `colorValue` was added to be more reliably used as you will be guaranteed to have a color
- Color palette is now optional. if color palette is null, the editor defaults to using the rainbow and lumen color pickers

Preview:
![image](https://user-images.githubusercontent.com/91709/202622556-1e9c4917-38c6-42a5-b985-c6ee2a3f4a18.png)

I hope this PR is accepted. I want to keep adding features. I was thinking of adding a lasso tool, flood fill, and brush sizes. Let me know if that is interesting to you.